### PR TITLE
Update GNet_WP_R1.Rmd

### DIFF
--- a/MS/RMarkdownMs/GNet_WP_R1.Rmd
+++ b/MS/RMarkdownMs/GNet_WP_R1.Rmd
@@ -75,6 +75,7 @@ library(stringr)          #string manipulation
 library(parallelsugar)    #for parallel computing
 library(clValid)      #clustering
 library(MASS)         #clustering
+library(parallel)     #for detectCores() function
 ```
 
 ```{r analysis-preferences}
@@ -346,9 +347,12 @@ Importantly, the prediction that gestures simplify is based on previous research
 
 We will follow a bottom-up approach to the study of kinematics as communicative systems. In the first stage of our analysis, we demonstrate the specific changes that occur in the kinematics of the gestures. In a second stage, we assess possible systematic interrelationships in kinematic patterns of gestures through gesture network analysis [@pouwGestureNetworksIntroducing2019]. We will discuss each step in this procedure in the following sections, and finally discuss our main gesture network entropy measure. In the supplemental information we reserve extra space for sanity checks of automated processing and graphical descriptive results of the key measures.  
 
-```{r construct_matrices_and_save, results = 'hide', cache= TRUE, eval = FALSE}
+```{r construct_matrices_and_save, results = 'hide', cache= TRUE, eval = TRUE}
 #NOTE this is the code that constructs individual level level gesture networks
 #This code takes a little time (up to 10 min) to run, and its output are all the distance matrices in the distance_matrices folder
+
+seeds <- subset(ts, as.character(generation) ==  "s")
+
 #The code chuck constructs:
   #Individual level matrices: Which are 5chainsx5generationx2participants of size 24x24 (576 cells) (networktype = 1)
   #seed level matrices:        Which are 5chains x with 24x24 matrices (networktype = 0)
@@ -444,7 +448,7 @@ for(gen in c(1:5))                                              #goes through al
 
 ```
 
-```{r main method figure, results = 'hide', cache= TRUE, eval = FALSE}
+```{r main method figure, results = 'hide', cache= TRUE, eval = TRUE}
 #extract a time series to show in the method figure
 exm <- ts[ts$generation=="s" & ts$seedsetnum == "arrest1",]
 


### PR DESCRIPTION
Minor fixes to be able to knit the document:
- Added a required library to set-up chunk
- Changed `eval` status of two code chunks
- Ensured that the `seeds` object was created early enough in the document.

Knitted successfully using:
R version 4.3.1 (2023-06-16)
Platform: aarch64-apple-darwin20 (64-bit)
Running under: macOS Sonoma 14.1.1

Matrix products: default
BLAS:   /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib 
LAPACK: /Library/Frameworks/R.framework/Versions/4.3-arm64/Resources/lib/libRlapack.dylib;  LAPACK version 3.11.0

locale:
[1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8

time zone: Europe/Madrid
tzcode source: internal

attached base packages:
[1] parallel  stats     graphics  grDevices utils     datasets 
[7] methods   base     

other attached packages:
 [1] MASS_7.3-60           clValid_0.7          
 [3] parallelsugar_0.0.0.2 stringr_1.5.1        
 [5] scales_1.3.0          cowplot_1.1.1        
 [7] tsne_0.1-3.1          EMAtools_0.1.4       
 [9] entropy_1.3.1         DescTools_0.99.50    
[11] r2glmm_0.1.2          pracma_2.4.2         
[13] signal_1.8-0          nlme_3.1-163         
[15] cluster_2.1.4         igraph_1.5.1         
[17] effsize_0.8.1         dtw_1.23-1           
[19] proxy_0.4-27          RColorBrewer_1.1-3   
[21] ggExtra_0.10.1        gridExtra_2.3        
[23] plotly_4.10.4         ggplot2_3.4.4        
[25] papaja_0.1.2          tinylabels_0.2.4     

loaded via a namespace (and not attached):
 [1] gld_2.6.6           sandwich_3.0-2     
 [3] readxl_1.4.3        rlang_1.1.3        
 [5] magrittr_2.0.3      multcomp_1.4-25    
 [7] e1071_1.7-13        compiler_4.3.1     
 [9] vctrs_0.6.5         pkgconfig_2.0.3    
[11] fastmap_1.1.1       backports_1.4.1    
[13] ellipsis_0.3.2      effectsize_0.8.6   
[15] utf8_1.2.4          promises_1.2.1     
[17] rmarkdown_2.25      nloptr_2.0.3       
[19] purrr_1.0.2         xfun_0.41          
[21] jsonlite_1.8.7      later_1.3.1        
[23] sjmisc_2.8.9        broom_1.0.5        
[25] R6_2.5.1            stringi_1.8.3      
[27] boot_1.3-28.1       numDeriv_2016.8-1.1
[29] cellranger_1.1.0    estimability_1.4.1 
[31] Rcpp_1.0.11         knitr_1.45         
[33] modelr_0.1.11       zoo_1.8-12         
[35] parameters_0.21.2   httpuv_1.6.12      
[37] Matrix_1.6-1.1      splines_4.3.1      
[39] tidyselect_1.2.0    rstudioapi_0.15.0  
[41] yaml_2.3.7          sjlabelled_1.2.0   
[43] codetools_0.2-19    miniUI_0.1.1.1     
[45] lmerTest_3.1-3      lattice_0.22-5     
[47] tibble_3.2.1        shiny_1.7.5.1      
[49] withr_3.0.0         bayestestR_0.13.1  
[51] coda_0.19-4         evaluate_0.23      
[53] survival_3.5-7      pillar_1.9.0       
[55] insight_0.19.6      generics_0.1.3     
[57] munsell_0.5.0       rootSolve_1.8.2.4  
[59] minqa_1.2.6         xtable_1.8-4       
[61] class_7.3-22        glue_1.7.0         
[63] emmeans_1.8.9       lmom_3.0           
[65] lazyeval_0.2.2      tools_4.3.1        
[67] data.table_1.14.8   lme4_1.1-34        
[69] Exact_3.2           mvtnorm_1.2-3      
[71] grid_4.3.1          tidyr_1.3.0        
[73] datawizard_0.9.0    colorspace_2.1-0   
[75] performance_0.10.8  cli_3.6.2          
[77] fansi_1.0.6         expm_0.999-7       
[79] viridisLite_0.4.2   sjstats_0.18.2     
[81] dplyr_1.1.3         gtable_0.3.4       
[83] DataCombine_0.2.21  digest_0.6.33      
[85] TH.data_1.1-2       htmlwidgets_1.6.2  
[87] htmltools_0.5.6.1   lifecycle_1.0.4    
[89] httr_1.4.7          mime_0.12   